### PR TITLE
Add an option to override the function used for fetch calls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -41,7 +41,7 @@ export default class Client {
     hostIdentifier,
     searchKey,
     engineName,
-    { endpointBase = "", cacheResponses = true, additionalHeaders } = {}
+    { endpointBase = "", cacheResponses = true, fetchFunction = fetch, additionalHeaders } = {}
   ) {
     this.additionalHeaders = additionalHeaders;
     this.searchKey = searchKey;
@@ -54,6 +54,7 @@ export default class Client {
     this.multiSearchPath = `engines/${this.engineName}/multi_search`;
     this.querySuggestionPath = `engines/${this.engineName}/query_suggestion`;
     this.clickPath = `engines/${this.engineName}/click`;
+    this.fetchFunction = fetchFunction;
   }
 
   /**
@@ -72,6 +73,7 @@ export default class Client {
       this.querySuggestionPath,
       params,
       this.cacheResponses,
+      this.fetchFunction,
       { additionalHeaders: this.additionalHeaders }
     ).then(handleErrorResponse);
   }
@@ -210,6 +212,7 @@ export default class Client {
       `${searchPath}.json`,
       params,
       this.cacheResponses,
+      this.fetchFunction,
       { additionalHeaders: this.additionalHeaders }
     ).then(handleErrorResponse);
   }
@@ -237,6 +240,7 @@ export default class Client {
       `${this.clickPath}.json`,
       params,
       this.cacheResponses,
+      this.fetchFunction,
       { additionalHeaders: this.additionalHeaders }
     ).then(handleErrorResponse);
   }

--- a/src/elastic_app_search.js
+++ b/src/elastic_app_search.js
@@ -10,13 +10,15 @@ export function createClient({
   engineName,
   endpointBase,
   cacheResponses,
-  additionalHeaders
+  additionalHeaders,
+  fetchFunction
 }) {
   hostIdentifier = hostIdentifier || accountHostKey; // accountHostKey is deprecated
   searchKey = searchKey || apiKey; //apiKey is deprecated
   return new Client(hostIdentifier, searchKey, engineName, {
     endpointBase,
     cacheResponses,
-    additionalHeaders
+    additionalHeaders,
+    fetchFunction
   });
 }

--- a/src/request.js
+++ b/src/request.js
@@ -8,6 +8,7 @@ export function request(
   path,
   params,
   cacheResponses,
+  fetchFunction = fetch,
   { additionalHeaders } = {}
 ) {
   const method = "POST";
@@ -19,7 +20,7 @@ export function request(
     }
   }
 
-  return _request(method, searchKey, apiEndpoint, path, params, {
+  return _request(method, searchKey, apiEndpoint, path, params, fetchFunction, {
     additionalHeaders
   }).then(response => {
     return response
@@ -41,6 +42,7 @@ function _request(
   apiEndpoint,
   path,
   params,
+  fetchFunction,
   { additionalHeaders } = {}
 ) {
   const headers = new Headers({
@@ -51,7 +53,7 @@ function _request(
     ...additionalHeaders
   });
 
-  return fetch(`${apiEndpoint}${path}`, {
+  return fetchFunction(`${apiEndpoint}${path}`, {
     method,
     headers,
     body: JSON.stringify(params),


### PR DESCRIPTION
A backwards compatible change that lets the `fetch()` function be overriden. This is when using it in [SvelteKit Load functions](https://kit.svelte.dev/docs#loading) where an optimised version of `fetch()` is available  for SSR apps. It will default to using `global.fetch` when not overridden, so there should be no incompatible changes to the existing API.

Usage:
```javascript
const fetchFunction = ...//

var client = ElasticAppSearch.createClient({
  fetchFunction,
});
```