### PR TITLE
Add option to specify fetch function per request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -8,7 +8,8 @@ export function request(
   path,
   params,
   cacheResponses,
-  { additionalHeaders } = {}
+  { additionalHeaders } = {},
+  fetchFunction = fetch,
 ) {
   const method = "POST";
   const key = cache.getKey(method, apiEndpoint + path, params);
@@ -19,9 +20,15 @@ export function request(
     }
   }
 
-  return _request(method, searchKey, apiEndpoint, path, params, {
-    additionalHeaders
-  }).then(response => {
+  return _request(
+    method,
+    searchKey,
+    apiEndpoint,
+    path,
+    params,
+    { additionalHeaders },
+    fetchFunction,
+  ).then(response => {
     return response
       .json()
       .then(json => {
@@ -41,7 +48,8 @@ function _request(
   apiEndpoint,
   path,
   params,
-  { additionalHeaders } = {}
+  { additionalHeaders } = {},
+  fetchFunction = fetch,
 ) {
   const headers = new Headers({
     ...(searchKey && { Authorization: `Bearer ${searchKey}` }),
@@ -51,7 +59,7 @@ function _request(
     ...additionalHeaders
   });
 
-  return fetch(`${apiEndpoint}${path}`, {
+  return fetchFunction(`${apiEndpoint}${path}`, {
     method,
     headers,
     body: JSON.stringify(params),


### PR DESCRIPTION
This adds the option to specify what function to use for `fetch` requests.
Itt adds compatibility for using AppSearch in [SvelteKit load functions](https://kit.svelte.dev/docs#loading)

Backwards compatible, but allows to specify a custom fetch function per request.

```nodejs
const fetchFn = require('node-fetch')
const result = await client.search(query.get('q'), options, fetchFn)
```

Or uses the globally available fetch if not specified:
```nodejs
const result = await client.search(query.get('q'), options)
```

Example usage in SvelteKit load function:
```svelte
// index.svelte

<script context="module">
import { createClient } from '@elastic/app-search-javascript'
const client = createClient({})

export const load = async ({ fetch }) => {
  const result = await client.search('foo', {}, fetch)
  return { props: { result } }
}
</script>

<script>
export let result
</script>

<pre>
  {JSON.stringify(result, null, 2)}
</pre>
```