### PR TITLE
[Client Telemetry] Enables reporting meta headers for client usage based telemetry

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Jest tests",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "stopOnEntry": false,
+      "args": ["--runInBand", "--forceExit", "--watch"],
+      "cwd": "${workspaceRoot}",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "precommit": "lint-staged"
   },
   "jest": {
-    "testURL": "http://localhost/"
+    "testURL": "http://localhost/",
+    "testEnvironment": "jsdom"
   },
   "lint-staged": {
     "*.js": [

--- a/src/request.js
+++ b/src/request.js
@@ -43,11 +43,14 @@ function _request(
   params,
   { additionalHeaders } = {}
 ) {
+  const jsVersion = typeof window !== "undefined" ? "browser" : process.version;
+  const metaHeader = `ent=${version}-legacy,js=${jsVersion},t=${version}-legacy,ft=universal`;
   const headers = new Headers({
     ...(searchKey && { Authorization: `Bearer ${searchKey}` }),
     "Content-Type": "application/json",
     "X-Swiftype-Client": "elastic-app-search-javascript",
     "X-Swiftype-Client-Version": version,
+    "x-elastic-client-meta": metaHeader,
     ...additionalHeaders
   });
 

--- a/tests/request.node.spec.js
+++ b/tests/request.node.spec.js
@@ -37,5 +37,9 @@ describe("request", () => {
     expect(options.headers.get("x-elastic-client-meta")).toEqual(
       `ent=${version}-legacy,js=${nodeVersion},t=${version}-legacy,ft=universal`
     );
+    const validHeaderRegex = /^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/;
+    expect(options.headers.get("x-elastic-client-meta")).toMatch(
+      validHeaderRegex
+    );
   });
 });

--- a/tests/request.node.spec.js
+++ b/tests/request.node.spec.js
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+
+import { request } from "../src/request";
+import { Headers } from "node-fetch";
+import { version } from "../package.json";
+const nodeVersion = process.version;
+
+describe("request", () => {
+  const responseJson = {};
+  const response = {
+    json: () => Promise.resolve(responseJson)
+  };
+
+  const searchKey = "api-12345";
+  const endpoint = "http://www.example.com";
+  const path = "/v1/search";
+  const params = {
+    a: "a"
+  };
+
+  beforeEach(() => {
+    global.Headers = Headers;
+    jest.resetAllMocks();
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+  });
+
+  it("will have the correct node based meta headers when running in node context", async () => {
+    expect(global.window).not.toBeDefined();
+    const res = await request(searchKey, endpoint, path, params, false);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+    var [_, options] = global.fetch.mock.calls[0];
+    expect(options.headers.get("x-elastic-client-meta")).toEqual(
+      `ent=${version}-legacy,js=${nodeVersion},t=${version}-legacy,ft=universal`
+    );
+  });
+});

--- a/tests/request.node.spec.js
+++ b/tests/request.node.spec.js
@@ -7,7 +7,7 @@ import { Headers } from "node-fetch";
 import { version } from "../package.json";
 const nodeVersion = process.version;
 
-describe("request", () => {
+describe("request - within node context", () => {
   const responseJson = {};
   const response = {
     json: () => Promise.resolve(responseJson)

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -127,5 +127,9 @@ describe("request", () => {
     expect(options.headers.get("x-elastic-client-meta")).toEqual(
       `ent=${version}-legacy,js=browser,t=${version}-legacy,ft=universal`
     );
+    const validHeaderRegex = /^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/;
+    expect(options.headers.get("x-elastic-client-meta")).toMatch(
+      validHeaderRegex
+    );
   });
 });

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -1,5 +1,6 @@
 import { request } from "../src/request";
 import { Headers } from "node-fetch";
+import { version } from "../package.json";
 
 describe("request", () => {
   const responseJson = {};
@@ -115,5 +116,16 @@ describe("request", () => {
     const res = await request(searchKey, endpoint, path, params, false);
     expect(res.response).toBe(response);
     expect(global.fetch.mock.calls.length).toBe(1);
+  });
+
+  it("will have the correct browser based meta headers when running in browser context", async () => {
+    expect(global.window).toBeDefined();
+    const res = await request(searchKey, endpoint, path, params, false);
+    expect(res.response).toBe(response);
+    expect(global.fetch.mock.calls.length).toBe(1);
+    var [_, options] = global.fetch.mock.calls[0];
+    expect(options.headers.get("x-elastic-client-meta")).toEqual(
+      `ent=${version}-legacy,js=browser,t=${version}-legacy,ft=universal`
+    );
   });
 });


### PR DESCRIPTION
This PR adds to the request a http header `x-elastic-client-meta` which contains information about the client thats used to perform the request on cloud. This header is used to track client usage on cloud. The value follows a spec [documented here](https://github.com/elastic/clients-team/blob/master/knowledgebase/specifications/client-meta-header.md) and is validated based on a regex mentioned in the spec doc. 

`-legacy` is included to differentiate it between the new universal enterprise search client and the current, in-use client which is deemed "legacy". If the client is run within the browser, we use `browser` for the JS version value. If its running in node context, use the nodejs version.  