### PR TITLE
Adds `record_analytics` boolean flag when search is for disjunctive facet search calls

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
       "stopOnEntry": false,
-      "args": ["--runInBand", "--forceExit", "--watch"],
+      "args": ["--runInBand", "--forceExit", "--watch", "--verbose"],
       "cwd": "${workspaceRoot}",
       "preLaunchTask": null,
       "runtimeExecutable": null,

--- a/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_deps_also_license
+++ b/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_deps_also_license
@@ -5,7 +5,7 @@ x-swiftype-client: elastic-app-search-javascript
 x-swiftype-client-version: 8.1.1
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"license\":\"BSD\"}]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]},\"analytics\":{\"tags\":[\"Facet-Only\"]}}
+body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"license\":\"BSD\"}]},\"facets\":{\"dependencies\":[{\"type\":\"value\",\"size\":3}]},\"record_analytics\":false,\"analytics\":{\"tags\":[\"Facet-Only\"]}}
 
 HTTP/1.1 200 OK
 date: Thu, 27 Sep 2018 21:19:12 GMT

--- a/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_deps_also_license_no_array_syntax
+++ b/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_deps_also_license_no_array_syntax
@@ -5,7 +5,7 @@ x-swiftype-client: elastic-app-search-javascript
 x-swiftype-client-version: 8.1.1
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3}},\"analytics\":{\"tags\":[\"Facet-Only\"]}}
+body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":{\"type\":\"value\",\"size\":3}},\"record_analytics\":false,\"analytics\":{\"tags\":[\"Facet-Only\"]}}
 
 HTTP/1.1 200 OK
 date: Fri, 28 Sep 2018 20:07:24 GMT

--- a/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_licence_override_tags
+++ b/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_licence_override_tags
@@ -6,10 +6,10 @@ x-swiftype-client-version: 8.1.1
 x-elastic-client-meta: ent=8.1.1-legacy,js=browser,t=8.1.1-legacy,ft=universal
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"analytics\":{\"tags\":[\"Facet-Only\"]},\"record_analytics\":false}
+body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"analytics\":{\"tags\":[\"FromSERP\",\"Disjunctive\"]},\"record_analytics\":false}
 
 HTTP/1.1 200 OK
-date: Fri, 06 May 2022 15:25:51 GMT
+date: Fri, 06 May 2022 19:35:53 GMT
 content-type: application/json; charset=utf-8
 transfer-encoding: chunked
 connection: close
@@ -22,14 +22,14 @@ x-swiftype-backend-region: dal
 x-swiftype-backend-datacenter: dal10
 x-swiftype-backend-node: app-api03a.dal10
 x-ratelimit-limit: 12000
-x-ratelimit-remaining: 11998
-etag: W/"680394011bb0efcb7a53ebd964a1127f"
+x-ratelimit-remaining: 11999
+etag: W/"10be0071db0ead6986f2ddf45b896207"
 cache-control: max-age=0, private, must-revalidate
-x-request-id: 73ed894a358f45bc79fb829d2427d9d9
-x-runtime: 0.086157
+x-request-id: 78e10ad9edfafd32ff71faddaaaa6292
+x-runtime: 0.244323
 x-swiftype-frontend-datacenter: dal10
 x-swiftype-frontend-node: web02b.dal10
 x-swiftype-edge-datacenter: dal10
 x-swiftype-edge-node: web02b.dal10
 
-{"meta":{"alerts":[],"warnings":[],"page":{"current":1,"total_pages":1,"total_results":642,"size":0},"request_id":"73ed894a358f45bc79fb829d2427d9d9"},"results":[],"facets":{"license":[{"type":"value","data":[{"value":"MIT","count":101},{"value":"BSD","count":33},{"value":"MIT/X11","count":3}]}]}}
+{"meta":{"alerts":[],"warnings":[],"page":{"current":1,"total_pages":1,"total_results":642,"size":0},"request_id":"78e10ad9edfafd32ff71faddaaaa6292"},"results":[],"facets":{"license":[{"type":"value","data":[{"value":"MIT","count":101},{"value":"BSD","count":33},{"value":"MIT/X11","count":3}]}]}}

--- a/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_license
+++ b/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_license
@@ -5,7 +5,7 @@ x-swiftype-client: elastic-app-search-javascript
 x-swiftype-client-version: 8.1.1
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"analytics\":{\"tags\":[\"Facet-Only\"]}}
+body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"record_analytics\":false,\"analytics\":{\"tags\":[\"Facet-Only\"]}}
 
 HTTP/1.1 200 OK
 date: Thu, 27 Sep 2018 20:36:08 GMT

--- a/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_license_also_deps
+++ b/fixtures/host-2376rb.api.swiftype.com-443/disjunctive_license_also_deps
@@ -5,7 +5,7 @@ x-swiftype-client: elastic-app-search-javascript
 x-swiftype-client-version: 8.1.1
 accept: */*
 accept-encoding: gzip,deflate
-body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"analytics\":{\"tags\":[\"Facet-Only\"]}}
+body: {\"query\":\"cat\",\"page\":{\"size\":0},\"filters\":{\"all\":[{\"dependencies\":\"socket.io\"}]},\"facets\":{\"license\":[{\"type\":\"value\",\"size\":3}]},\"record_analytics\":false,\"analytics\":{\"tags\":[\"Facet-Only\"]}}
 
 HTTP/1.1 200 OK
 date: Thu, 27 Sep 2018 21:04:37 GMT

--- a/src/client.js
+++ b/src/client.js
@@ -172,6 +172,7 @@ export default class Client {
         return this._performSearch({
           ...params,
           filters: filters.removeFilter(appliedDisjunctiveFilter).filtersJSON,
+          record_analytics: false,
           page: {
             ...page,
             // Set this to 0 for performance, since disjunctive queries

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -225,7 +225,7 @@ describe("Client", () => {
         );
       });
 
-      // Fixture: disjunctive_license
+      // Fixture: disjunctive_license_override_tags
       // Fixture: search_filter_and_multi_facet_with_tags
       it("will not pass tags through on disjunctive queries", async () => {
         // Note, this is tested implicitly by using the same disjunctive fixture as the previous test. This
@@ -401,7 +401,7 @@ describe("Client", () => {
     });
 
     // Fixture: additional_headers
-    it.only("should pass along additional headers", async () => {
+    it("should pass along additional headers", async () => {
       const headerClient = new Client(hostIdentifier, searchKey, engineName, {
         additionalHeaders: { "Content-Type": "bogus/format" }
       });


### PR DESCRIPTION
- Added flag to the network call + updated the tests
Fixes https://github.com/elastic/search-ui/issues/730  
related https://github.com/elastic/enterprise-search-team/issues/1571

![image](https://user-images.githubusercontent.com/49480/167207948-361c3ea1-8c62-4547-9611-b5257a6e40cc.png)
